### PR TITLE
Deprecation warning in Rails ~> 2.3.9

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -4,7 +4,7 @@ controller_path = File.dirname(__FILE__) + '/lib/controllers'
 $LOAD_PATH << controller_path
 
 if defined?(ActiveSupport::Dependencies)
-  if Rails::VERSION::MAJOR >= 3
+  if ActiveSupport::Dependencies.respond_to?(:autoload_paths)
     ActiveSupport::Dependencies.autoload_paths << controller_path
   else
     ActiveSupport::Dependencies.load_paths << controller_path


### PR DESCRIPTION
DEPRECATION WARNING: ActiveSupport::Dependencies.load_paths is deprecated, please use autoload_paths instead. (called from evaluate_init_rb at vendor/plugins/fitter_happier/init.rb:10)
